### PR TITLE
Add Dynamic Script Function

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Reference Include="WindowsBase" />
     <PackageReference Include="Calamari.AzureScripting" Version="7.1.0" />
-    <PackageReference Include="Calamari.Common" Version="14.8.1" />
+    <PackageReference Include="Calamari.Common" Version="14.8.2" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Management.Compute" Version="14.0.0" />

--- a/source/Sashimi/AzureCloudServiceServiceMessageHandler.cs
+++ b/source/Sashimi/AzureCloudServiceServiceMessageHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Octopus.Diagnostics;
 using Octostache;
 using Sashimi.AzureCloudService.Endpoints;
@@ -22,7 +21,24 @@ namespace Sashimi.AzureCloudService
 
         public string AuditEntryDescription => "Azure Cloud Service Target";
         public string ServiceMessageName => AzureCloudServiceServiceMessageNames.CreateTargetName;
-        public IEnumerable<ScriptFunctionRegistration> ScriptFunctionRegistrations { get; } = Enumerable.Empty<ScriptFunctionRegistration>();
+        public IEnumerable<ScriptFunctionRegistration> ScriptFunctionRegistrations { get; } = new List<ScriptFunctionRegistration>
+        {
+            new ScriptFunctionRegistration("OctopusAzureCloudServiceTarget",
+                                           "Creates a new Azure Cloud Service target.",
+                                           AzureCloudServiceServiceMessageNames.CreateTargetName,
+                                           new Dictionary<string, FunctionParameter>
+                                           {
+                                               { AzureCloudServiceServiceMessageNames.NameAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.AzureCloudServiceNameAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.AzureStorageAccountAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.AzureDeploymentSlotAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.SwapAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.InstanceCountAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.AccountIdOrNameAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.RolesAttribute, new FunctionParameter(ParameterType.String) },
+                                               { AzureCloudServiceServiceMessageNames.UpdateIfExistingAttribute, new FunctionParameter(ParameterType.Bool) }
+                                           })
+        };
 
         public Endpoint BuildEndpoint(IDictionary<string, string> messageProperties,
                                       VariableDictionary variables,
@@ -111,12 +127,15 @@ namespace Sashimi.AzureCloudService
         internal static class AzureCloudServiceServiceMessageNames
         {
             public const string CreateTargetName = "create-azurecloudservicetarget";
+            public const string NameAttribute = "name";
             public const string AccountIdOrNameAttribute = "octopusAccountIdOrName";
             public const string AzureCloudServiceNameAttribute = "azureCloudServiceName";
             public const string AzureStorageAccountAttribute = "azureStorageAccount";
             public const string AzureDeploymentSlotAttribute = "azureDeploymentSlot";
             public const string SwapAttribute = "swap";
             public const string InstanceCountAttribute = "instanceCount";
+            public const string RolesAttribute = "octopusRoles";
+            public const string UpdateIfExistingAttribute = "updateIfExisting";
         }
 
         internal static class AzureCloudServiceEndpointDeploymentSlot


### PR DESCRIPTION
Move `New-OctopusAzureCloudServiceTarget` into `Sashimi` as a script function registration, which make use of our `PowershellLanguage` generator at `Calamari` to generate the actual ps1 function. 

Please refer to its corresponding [Calamari PR](https://github.com/OctopusDeploy/Calamari/pull/661)