### PR TITLE
Batch of fixes for Sashimi.AzureScripting to target Server 2020.5

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Tests.Shared" Version="8.3.4" />
+        <PackageReference Include="Calamari.Tests.Shared" Version="8.5.4" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="nunit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/source/Calamari/App.config
+++ b/source/Calamari/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <runtime>
+        <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+    </runtime>
+</configuration>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,12 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Calamari.AzureScripting" Version="8.3.1" />
-    <PackageReference Include="Calamari.Scripting" Version="8.3.1" />
-    <PackageReference Include="Calamari.Common" Version="14.11.0" />
-    <PackageReference Include="Calamari.AzureScripting" Version="9.0.2" />
-    <PackageReference Include="Calamari.Scripting" Version="8.3.4" />
-    <PackageReference Include="Calamari.Common" Version="14.8.4" />
+    <PackageReference Include="Calamari.Common" Version="15.1.6" />
+    <PackageReference Include="Calamari.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Calamari.Scripting" Version="8.4.0" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Management.Compute" Version="14.0.0" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.3.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.5.4" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.22" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.0.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.3.4" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.5.4" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.38.5" />
+</packages>


### PR DESCRIPTION
Fixes both:
- https://github.com/OctopusDeploy/Issues/issues/6683
- https://github.com/OctopusDeploy/Issues/issues/6778

For netfull we need to explicitly enable long file paths in the config file.
Update references to Calamari + Sashimi to match what the Server is referencing
Had to lock the cake version because v1 does not work!

Cake error with v1:
![image](https://user-images.githubusercontent.com/122651/109563561-ab23ea80-7b2b-11eb-9406-c83ad9dc4a59.png)
