### PR TITLE
Update references to Calamari + Sashimi for targeting 2020.6 server

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Reference Include="WindowsBase" />
     <PackageReference Include="Calamari.Common" Version="17.0.1" />
-    <PackageReference Include="Calamari.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="10.0.1" />
     <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Reference Include="WindowsBase" />
     <PackageReference Include="Calamari.Common" Version="17.0.1" />
-    <PackageReference Include="Calamari.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="10.0.0" />
     <PackageReference Include="Calamari.Scripting" Version="8.6.4" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.4" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="8.6.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
     <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="9.2.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.4" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="8.6.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="10.0.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
## Description
This PR completes the work started in https://github.com/OctopusDeploy/Sashimi.AzureCloudService/pull/11

This PR increases the Calamari version to 17.0.1 (Server v2020.6 is still on Calamari v16.0.7), as part of merging this PR with the Server I will be bumping the Calamari version to match the one in this PR.

### Is it safe to bump Calamari to v17.0.1?
Yes I have reviewed the changes - https://github.com/OctopusDeploy/Calamari/compare/16.0.7...17.0.1