### PR TITLE
Updates Sashimi versions to include Azure bundled tools warnings

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,11 +7,11 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Tests.Shared" Version="12.0.0" />
+        <PackageReference Include="Calamari.Tests.Shared" Version="13.3.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="nunit" Version="3.13.1" />
+        <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="Shouldly" Version="2.8.2" />

--- a/source/Calamari.Tests/DeployAzureCloudServiceCommandFixture.cs
+++ b/source/Calamari.Tests/DeployAzureCloudServiceCommandFixture.cs
@@ -245,8 +245,19 @@ namespace Calamari.AzureCloudService.Tests
 
         async Task EnsureDeploymentStatus(DeploymentStatus requiredStatus, ComputeManagementClient client, string serviceName, DeploymentSlot deploymentSlot)
         {
-            var deployment = await client.Deployments.GetBySlotAsync(serviceName, deploymentSlot);
-            deployment.Status.Should().Be(requiredStatus);
+            DeploymentStatus status;
+            var counter = 0;
+            do
+            {
+                var deployment = await client.Deployments.GetBySlotAsync(serviceName, deploymentSlot);
+                status = deployment.Status;
+                if (status == requiredStatus)
+                {
+                    break;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            } while (counter++ < 5);
+            status.Should().Be(requiredStatus);
         }
 
         static X509Certificate2 CreateManagementCertificate(string certificate)

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Calamari.Common" Version="19.2.0" />
-    <PackageReference Include="Calamari.AzureScripting" Version="12.0.0" />
-    <PackageReference Include="Calamari.Scripting" Version="12.0.0" />
+    <PackageReference Include="Calamari.Common" Version="19.2.5" />
+    <PackageReference Include="Calamari.AzureScripting" Version="13.2.0" />
+    <PackageReference Include="Calamari.Scripting" Version="13.3.0" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Management.Compute" Version="14.0.0" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.0.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.1.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -13,11 +13,11 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <ProjectReference Include="..\Sashimi\Sashimi.csproj" />
     <PackageReference Include="Assent" Version="1.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.1.0" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.0.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.0.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates to use the latest Sashimi versions so as to include changes from https://github.com/OctopusDeploy/Sashimi.AzureScripting/pull/10