### PR TITLE
Bump Calamari.AzureScripting to 14.0.2

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Calamari.Common" Version="20.3.8" />
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.1" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.0" />
+    <PackageReference Include="Calamari.Common" Version="20.4.0" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.0.2" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Management.Compute" Version="14.0.0" />


### PR DESCRIPTION
Rolling dependency changes through to keep things up to date, no functional changes in this Sashimi as it's not a "Run a Script" step.

(Version bump results from fix for OctopusDeploy/Issues#7050, which changed the way Bash Script parameters are handled)