### PR TITLE
Bumps Calamari.* to 19.4.10 and Sashimi.* to 14.0.3 (Server 2021.2 Stream)

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Tests.Shared" Version="14.0.1" />
+        <PackageReference Include="Calamari.Tests.Shared" Version="14.0.3" />
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Calamari.Common" Version="19.4.6" />
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Calamari.Scripting" Version="14.0.1" />
+    <PackageReference Include="Calamari.Common" Version="19.4.10" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.0.3" />
+    <PackageReference Include="Calamari.Scripting" Version="14.0.3" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Management.Compute" Version="14.0.0" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.3" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.3" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Upstream changes:
* OctopusDeploy/Calamari#808
* OctopusDeploy/Sashimi#133
* OctopusDeploy/Sashimi.AzureScripting#19

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177