### PR TITLE
Bumps Calamari.* to 20.4.2, Sashimi.* to 14.1.3, and Sashimi.AzureScripting to 14.1.0

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -7,7 +7,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Calamari.Tests.Shared" Version="14.1.0" />
+        <PackageReference Include="Calamari.Tests.Shared" Version="14.1.3" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Calamari.Common" Version="20.4.0" />
-    <PackageReference Include="Calamari.AzureScripting" Version="14.0.2" />
-    <PackageReference Include="Calamari.Scripting" Version="14.1.1" />
+    <PackageReference Include="Calamari.Common" Version="20.4.2" />
+    <PackageReference Include="Calamari.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Calamari.Scripting" Version="14.1.3" />
     <PackageReference Include="Hyak.Common" Version="1.2.2" />
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />
     <PackageReference Include="Microsoft.WindowsAzure.Management.Compute" Version="14.0.0" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.3.20" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.1.3" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
   </ItemGroup>
 

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.1.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.1.3" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.3

Upstream changes:
* OctopusDeploy/Calamari#815
* OctopusDeploy/Sashimi#134
* OctopusDeploy/Sashimi.AzureScripting#20

Issues:
* OctopusDeploy/Issues/issues/6794
* OctopusDeploy/Issues/issues/7177